### PR TITLE
Update littlelink.blade.php

### DIFF
--- a/resources/views/littlelink.blade.php
+++ b/resources/views/littlelink.blade.php
@@ -11,7 +11,7 @@
   <!-- This shows a preview for title, description and avatar image of users profiles if shared on social media sites -->
 
     <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="{{ url('') }}/@littlelink_name">
+    <meta property="og:url" content="{{ url('') }}/{{ "@".$littlelink_name }}">
     <meta property="og:type" content="website">
     <meta property="og:title" content="{{ $userinfo->name }}">
     <meta property="og:description" content="{{ $userinfo->littlelink_description }}">
@@ -23,8 +23,8 @@
     
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="{{ url('') }}/@littlelink_name">
-    <meta property="twitter:url" content="{{ url('') }}/@littlelink_name">
+    <meta property="twitter:domain" content="{{ url('') }}/{{ "@".$littlelink_name }}">
+    <meta property="twitter:url" content="{{ url('') }}/{{ "@".$littlelink_name }}">
     <meta name="twitter:title" content="{{ $userinfo->littlelink_name }}">
     <meta name="twitter:description" content="{{ $userinfo->littlelink_description }}">
     @if(file_exists(base_path("img/$littlelink_name" . ".png" )))


### PR DESCRIPTION
Noticed that when you paste a link to facebook/twitter the preview card doesn't display properly.
So display contents of $littlelink_name where it's supposed to be.