### PR TITLE
retrieve link url from database rather than request url

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -183,21 +183,15 @@ class UserController extends Controller
     public function clickNumber(request $request)
     {
         $link = $request->link;
-        $query = $request->query();
         $linkId = $request->id;
 
         if(empty($link && $linkId))
         {
             return abort(404);
         }
-        
-        if(!empty($query)) {
-        	$qs = [];
-        	foreach($query as $qk => $qv) { $qs[] = $qk .'='. $qv; }
-        	$link = $link .'?'. implode('&', $qs);
-        }
 
         Link::where('id', $linkId)->increment('click_number', 1);
+        $link = Link::select('link')->where('id', $linkId)->get()[0]['link'];
 
         return redirect()->away($link);
     }


### PR DESCRIPTION
increases robustness and solve issues with sloppy redirect interpretation across browsers

Also removes the need to re-interpret any query strings that are passed into the request url as a result of links in the database containing query strings

fixes https://github.com/JulianPrieber/littlelink-custom/issues/165