### PR TITLE
Fix bulleted list view issue (#635)

### DIFF
--- a/resources/views/linkstack/elements/bio.blade.php
+++ b/resources/views/linkstack/elements/bio.blade.php
@@ -1,3 +1,3 @@
         <!-- Short Bio -->
-        <style>.description-parent * {margin-bottom: 1em;}.description-parent {padding-bottom: 30px;}</style>
+        <style>.description-parent * {margin-bottom: 1em;}.description-parent {padding-bottom: 30px;}.description-parent ul,.description-parent ol{text-align:left;display:table;margin:0 auto 1em auto;padding-left:20px;}.description-parent li{text-align:left;}</style>
         <center><div class="fadein description-parent dynamic-contrast"><p class="fadein">@if(env('ALLOW_USER_HTML') === true){!! $info->littlelink_description !!}@else{{ $info->littlelink_description }}@endif</p></div></center>


### PR DESCRIPTION
Fixes #635
## Fix misalignment of bulleted lists in public profile description

### Issue
Bulleted lists (`<ul>`, `<ol>`) in the user's public profile description were displayed incorrectly.

The description content is wrapped in a `<center>` tag, causing list elements to inherit centered alignment. This resulted in bullets appearing detached from their text and lists looking visually misaligned.

### Fix
Adjusted markup / styles to correctly render bullet points
