### PR TITLE
Fix backup download link — missing file= query parameter

### DIFF
--- a/resources/views/components/config/backups.blade.php
+++ b/resources/views/components/config/backups.blade.php
@@ -113,7 +113,7 @@
             while (false !== ($entry = readdir($handle))) {
                 if ($entry != '.' && $entry != '..') {
                     $entrys = substr($entry, 17);
-                    echo '<div class="button-entrance"><a class="buttondm button-hover icon-hover" style="color:#ffffff; background-color:#000;" href="' . url('admin/backups') . '/?' . $entry . '"><i style="color: " class="icon hvr-icon fa fa-download"></i>&nbsp; ';
+                    echo '<div class="button-entrance"><a class="buttondm button-hover icon-hover" style="color:#ffffff; background-color:#000;" href="' . url('admin/backups') . '?file=' . $entry . '"><i style="color: " class="icon hvr-icon fa fa-download"></i>&nbsp; ';
                     print_r($entrys);
                     echo '</a></div><br>';
                 }


### PR DESCRIPTION
## Bug

Backup files cannot be downloaded from the admin panel. Clicking a backup download button navigates the browser to the page URL instead of triggering a file download, and throws a JS error:

\`\`\`
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
\`\`\`

## Root Cause

The download link is generated with the filename as a bare query key:

\`\`\`php
// Generates: /admin/backups/?filename.zip
url('admin/backups') . '/?' . $entry
\`\`\`

But the download handler checks \`$_GET['file']\`:

\`\`\`php
if (isset($_GET['file'])) {
    $filename = $_GET['file'];
    // ... serve file
}
\`\`\`

Since \`$_GET['file']\` is never set, the handler is skipped and the page renders as HTML, causing the JS error.

## Fix

\`\`\`php
// Generates: /admin/backups?file=filename.zip
url('admin/backups') . '?file=' . $entry
\`\`\`

Two corrections in one:
1. Removed the stray \`/\` before \`?\`
2. Changed \`$entry\` to \`file=$entry\` to match what the handler expects

## Test

Verified on a self-hosted instance behind an nginx reverse proxy — backup downloads work correctly after this change.