### PR TITLE
Fix stored XSS via event handlers in user profile description

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -609,6 +609,8 @@ class UserController extends Controller
         $profilePhoto = $request->file('image');
         $pageName = $request->littlelink_name;
         $pageDescription = strip_tags($request->pageDescription, '<a><p><strong><i><ul><ol><li><blockquote><h2><h3><h4>');
+        $pageDescription = preg_replace('/\bon\w+\s*=\s*(["\']).*?\1/i', '', $pageDescription);
+        $pageDescription = preg_replace('/\bon\w+\s*=\s*[^\s>]*/i', '', $pageDescription);
         $pageDescription = preg_replace("/<a([^>]*)>/i", "<a $1 rel=\"noopener noreferrer nofollow\">", $pageDescription);
         $pageDescription = strip_tags_except_allowed_protocols($pageDescription);
         $name = $request->name;


### PR DESCRIPTION
## Summary

- `strip_tags()` in `UserController::editPage()` allows `<a>` tags but does not strip HTML attributes, allowing JavaScript event handlers (e.g. `onmouseover`, `onfocus`, `onclick`) to pass through
- The description is rendered unescaped via `{!! !!}` in `linkinfo.blade.php`, enabling stored XSS
- Added regex filters to strip all `on*` event handler attributes (both quoted and unquoted values) before saving to the database

## Steps to reproduce

1. Login as any registered user
2. POST directly to `/studio/page` (bypassing CKEditor) with `pageDescription` set to:
   ```html
   <a href="https://x" onmouseover="alert(document.cookie)">Hover me</a>
   ```
3. Visit `/info/{link_id}` — hovering the link triggers the JavaScript

## Test plan

- [x] Verified the `onmouseover` payload is stripped after the fix
- [x] Verified legitimate HTML tags (`<a>`, `<p>`, `<strong>`, etc.) still work
- [x] Verified `href` attributes on `<a>` tags are preserved