### PR TITLE
Fix IDOR in link management endpoints

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -292,6 +292,9 @@ class UserController extends Controller
         $filteredLinkData['type_params'] = json_encode($customParams);
 
         if ($OrigLink) {
+            if ($OrigLink->user_id !== $userId) {
+                abort(403);
+            }
             $currentValues = $OrigLink->getAttributes();
             $nonNullFilteredLinkData = array_filter($filteredLinkData, function($value) {return !is_null($value);});
             $updatedValues = array_merge($currentValues, $nonNullFilteredLinkData);
@@ -335,6 +338,7 @@ class UserController extends Controller
 
             $linkNewOrders[$linkId] = $newOrder;
             Link::where("id", $linkId)
+                ->where("user_id", Auth::user()->id)
                 ->update([
                     'order' => $newOrder
                 ]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -120,7 +120,7 @@ Route::get('/studio/rem-background', [UserController::class, 'removeBackground']
 Route::get('/studio/profile', [UserController::class, 'showProfile'])->name('showProfile');
 Route::post('/studio/profile', [UserController::class, 'editProfile'])->name('editProfile');
 Route::post('/edit-icons', [UserController::class, 'editIcons'])->name('editIcons');
-Route::get('/clearIcon/{id}', [UserController::class, 'clearIcon'])->name('clearIcon');
+Route::get('/clearIcon/{id}', [UserController::class, 'clearIcon'])->name('clearIcon')->middleware('link-id');
 Route::get('/studio/page/delprofilepicture', [UserController::class, 'delProfilePicture'])->name('delProfilePicture');
 Route::get('/studio/delete-user/{id}', [UserController::class, 'deleteUser'])->name('deleteUser')->middleware('verified');
 Route::post('/auth-as', [AdminController::class, 'authAs'])->name('authAs');


### PR DESCRIPTION
## Summary

Three link management endpoints accept user-supplied link IDs without verifying the authenticated user owns the targeted link, allowing any registered user to modify other users' links.

- **`POST /studio/edit-link`** (`saveLink`): Added ownership check — aborts 403 if link belongs to another user
- **`POST /studio/sort-link`** (`sortLinks`): Added `user_id` where clause so updates only affect the authenticated user's links
- **`GET /clearIcon/{id}`**: Added existing `link-id` middleware to the route

## Steps to reproduce

1. Create two user accounts (A and B), each with at least one link
2. Login as user A
3. Open browser console and POST to `/studio/edit-link` with user B's link ID:
```javascript
fetch('/studio/edit-link', {
  method: 'POST',
  headers: {
    'Content-Type': 'application/x-www-form-urlencoded',
    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
  },
  body: new URLSearchParams({
    linkid: '<USER_B_LINK_ID>',
    link: 'https://evil-site.com',
    title: 'Modified',
    typename: 'link',
    button: 'custom_website'
  })
}).then(r => console.log('Status:', r.status))
```
4. Before fix: user B's link is overwritten. After fix: 403 Forbidden.

## Test plan

- [x] Verified `saveLink` returns 403 when targeting another user's link
- [x] Verified `sortLinks` silently ignores link IDs not owned by the user
- [x] Verified `clearIcon` returns 403 via `link-id` middleware
- [x] Verified normal link editing/sorting/icon clearing still works for the link owner