### PR TITLE
Add Friendica to Rel=Me supported services (#971)

### DIFF
--- a/resources/views/linkstack/modules/meta.blade.php
+++ b/resources/views/linkstack/modules/meta.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Fediverse rel="me" links --}}
 @php
-  $relMe = "mastodon, firefish, streams";
+  $relMe = "mastodon, firefish, streams, friendica";
   $relMeList = explode(', ', $relMe);
 @endphp
 


### PR DESCRIPTION
Adds Friendica to the list of Fediverse platforms that get Rel=Me links on user profile pages.

**Changes:**
- Added "friendica" to the $relMe string in the meta module

Fixes #971

**Testing:** Change is a one-line addition to a comma-separated string. No test suite exists in the project, but the logic is identical to the existing entries.