### PR TITLE
[codex] skip empty vCard addresses

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -409,8 +409,12 @@ class UserController extends Controller
         $vcard->addPhoneNumber($data['home_phone'], 'HOME');
         $vcard->addPhoneNumber($data['work_phone'], 'WORK');
         $vcard->addPhoneNumber($data['cell_phone'], 'CELL');
-        $vcard->addAddress($data['home_address_street'], '', $data['home_address_city'], $data['home_address_state'], $data['home_address_zip'], $data['home_address_country'], 'HOME');
-        $vcard->addAddress($data['work_address_street'], '', $data['work_address_city'], $data['work_address_state'], $data['work_address_zip'], $data['work_address_country'], 'WORK');
+        if (array_filter([$data['home_address_street'], $data['home_address_city'], $data['home_address_state'], $data['home_address_zip'], $data['home_address_country']], fn ($part) => trim((string) $part) !== '')) {
+            $vcard->addAddress($data['home_address_street'], '', $data['home_address_city'], $data['home_address_state'], $data['home_address_zip'], $data['home_address_country'], 'HOME');
+        }
+        if (array_filter([$data['work_address_street'], $data['work_address_city'], $data['work_address_state'], $data['work_address_zip'], $data['work_address_country']], fn ($part) => trim((string) $part) !== '')) {
+            $vcard->addAddress($data['work_address_street'], '', $data['work_address_city'], $data['work_address_state'], $data['work_address_zip'], $data['work_address_country'], 'WORK');
+        }
         
 
         // $vcard->addPhoto(base_path('img/1.png'));


### PR DESCRIPTION
## Summary
- skip HOME and WORK address entries when all address fields are blank
- keep existing vCard output unchanged when any address field is present

## Why
The vCard endpoint always called `addAddress()` for HOME and WORK. On iOS this can create empty HOME/WORK address entries, making the device try to resolve a location from just the label.

Fixes #961.

## Validation
- `git diff --check`
- `php -l app/Http/Controllers/UserController.php` not run: PHP is not installed in this local environment
