### PR TITLE
[codex] apply dynamic contrast to text blocks

### DIFF
--- a/resources/views/components/pageitems/text-display.blade.php
+++ b/resources/views/components/pageitems/text-display.blade.php
@@ -1,3 +1,2 @@
 
-<div class='button-text'> {{$title}}</div>
-
+<div class='button-text dynamic-contrast'> {{$title}}</div>


### PR DESCRIPTION
Fixes #966.

## Summary
- add the existing dynamic-contrast class to custom text block output
- keep the existing button-text styling intact

## Validation
- git diff --check
- php -l resources/views/components/pageitems/text-display.blade.php (not run: php is not installed in this local environment)